### PR TITLE
Gradle build file updated

### DIFF
--- a/Kovalchuk/04-jsf/build.gradle
+++ b/Kovalchuk/04-jsf/build.gradle
@@ -1,47 +1,44 @@
+plugins {
+    id 'java'
+    id 'war'
+    id 'io.spring.dependency-management' version '0.6.1.RELEASE'
+}
+
 group 'io.github.anxolerd.jee'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    repositories {
-        mavenCentral()
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories { jcenter() }
+
+dependencyManagement {
+    imports {
+        mavenBom 'org.wildfly.bom:wildfly-javaee7-with-tools:10.1.0.Final'
     }
-}
-
-apply plugin: 'java'
-apply plugin: 'war'
-
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
     // Use annotation preprocessor to simplify java code
     compileOnly 'org.projectlombok:lombok:1.16.10'
 
-    // Need this only for status code constants
-    providedCompile 'javax.servlet:servlet-api:2.5'
+    // Web
+    compileOnly 'org.jboss.spec.javax.faces:jboss-jsf-api_2.2_spec'
+    compile 'org.primefaces:primefaces:6.0'
 
     // CDI
-    providedCompile 'javax.enterprise:cdi-api:1.2'
+    compileOnly 'javax.enterprise:cdi-api'
+
+    // Persistence dependencies
+    compileOnly 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api'
+    compileOnly 'org.hibernate:hibernate-core'
+
+    // Bean Validation Implementation
+    compileOnly 'org.hibernate:hibernate-validator'
+    compileOnly 'org.hibernate:hibernate-validator-annotation-processor'
 
     // Logging
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.7'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
-
-    // Persistence dependencies
-    compile 'org.hibernate.javax.persistence:hibernate-jpa-2.0-api:1.0.1.Final'
-    providedCompile 'org.hibernate:hibernate-core:5.2.3.Final'
-    providedCompile 'org.hibernate:hibernate-annotations:3.5.6-Final'
-    providedCompile 'javax.transaction:javax.transaction-api:1.2'
-
-    // Bean Validation Implementation
-    providedCompile 'org.hibernate:hibernate-validator:5.2.3.Final'
-
-    // JSF
-    compile 'com.sun.faces:jsf-api:2.2.13'
-    compile 'com.sun.faces:jsf-impl:2.2.13'
-    compile 'org.primefaces:primefaces:6.0'
-
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.5.0'
 }

--- a/Kovalchuk/04-jsf/build.gradle
+++ b/Kovalchuk/04-jsf/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.16.10'
 
     // Web
+    compileOnly 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec'
     compileOnly 'org.jboss.spec.javax.faces:jboss-jsf-api_2.2_spec'
     compile 'org.primefaces:primefaces:6.0'
 
@@ -32,6 +33,7 @@ dependencies {
     // Persistence dependencies
     compileOnly 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api'
     compileOnly 'org.hibernate:hibernate-core'
+    compileOnly 'org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec'
 
     // Bean Validation Implementation
     compileOnly 'org.hibernate:hibernate-validator'


### PR DESCRIPTION
Dependency management simplified. Now only the version of application server needs to be specified. Instead of all component versions.